### PR TITLE
Add GitHub bounty lead workflow

### DIFF
--- a/archive/partners/github/github-based-marketing.md
+++ b/archive/partners/github/github-based-marketing.md
@@ -1,0 +1,100 @@
+# GitHub Based Marketing Workflow
+
+This workflow turns public GitHub issue search into a repeatable lead source for Ubiquity. The goal is to find projects already using bounty language, then approach only relevant maintainers with a concrete DevPool/Ubiquity angle.
+
+## Why This Channel Works
+
+Teams that mention bounties on GitHub already understand task-based contribution and public rewards. They are warmer than generic Web3 leads because they have at least one of these signals:
+
+- They fund work directly on issues.
+- They discuss contributor assignment and payment in public.
+- They already have unresolved work with `bounty`, `help wanted`, or `good first issue` labels.
+- They have contributors asking about payout mechanics.
+
+The outreach should not be a bulk comment campaign. It should be a shortlist-based process: identify the maintainer, verify that the repo has a real project behind it, then send a specific suggestion through the project's preferred contact channel.
+
+## Lead Generation
+
+Run the scraper from the repository root:
+
+```sh
+node scrapers/github-bounty-leads.js --per-query 20 --min-score 6
+```
+
+For CSV export:
+
+```sh
+node scrapers/github-bounty-leads.js --per-query 50 --min-score 7 --format csv > github-bounty-leads.csv
+```
+
+The script searches GitHub issues for bounty-related language, deduplicates results, and scores each lead. It works without credentials, but `GITHUB_TOKEN` is recommended to avoid low rate limits:
+
+```sh
+GITHUB_TOKEN=github_pat_xxx node scrapers/github-bounty-leads.js
+```
+
+## Scoring Rules
+
+Higher scores mean a lead is more likely to be worth manual review:
+
+- `+4` if the issue mentions at least `$20`.
+- `+2` if the issue mentions at least `$100`.
+- `+3` if the issue has a bounty label.
+- `+1` if it has `help wanted` or `good first issue`.
+- `+2` if the issue is open.
+- `+2` if comment volume is low.
+- `-2` if comment volume is already high.
+- `-3` for obvious test, demo, sandbox, fork, archive, or mirror repos.
+- `-5` for giveaway, referral, scam, or airdrop language.
+
+These rules bias toward real maintainers who have a bounty process but may not have a full contributor marketplace.
+
+## Manual Review Checklist
+
+Before contacting anyone, check:
+
+- The repository is active in the last 30 days.
+- The issue is not already assigned or solved by an open PR.
+- The bounty appears to be paid in money or a credible token, not only points.
+- The maintainer has a public contact path: GitHub profile email, project website, Discord, Telegram, or X.
+- Ubiquity has a clear improvement to offer: pricing automation, bounty lifecycle management, task verification, or contributor routing.
+
+Reject leads where the only possible action is public spam. A bad public comment damages the channel.
+
+## Outreach Pattern
+
+Use a short message that proves the issue was read:
+
+```text
+Hi <name>, I noticed <repo> is already using GitHub issues for bounties, especially <specific issue>.
+
+Ubiquity helps teams run the same workflow with assignment, pricing, verification, and payout tracking around GitHub issues. The useful fit here seems to be <one concrete pain point>.
+
+Would it be useful if I mapped one of your active bounty issues into a Ubiquity-style task flow so you can compare the process?
+```
+
+If the project has a community channel, send one message there. If not, use a GitHub discussion or maintainer email. Avoid commenting on unrelated issues.
+
+## Daily Operating Loop
+
+1. Run the scraper and export CSV.
+2. Review the top 20 leads manually.
+3. Pick 5 high-confidence maintainers.
+4. Write one specific outreach line per maintainer.
+5. Track replies in a simple sheet with `repo`, `contact`, `sent_at`, `reply`, and `next_step`.
+
+The expected output is not a large list. It is a small number of projects where the maintainer already has bounty intent and Ubiquity can remove operational friction.
+
+## Example Follow-Up
+
+```text
+Thanks. If helpful, I can put together a concrete example using <issue URL>: suggested price, acceptance criteria, verification gate, and payout handoff. That tends to make the difference clearer than a generic demo.
+```
+
+## Success Metrics
+
+- Number of qualified leads found per run.
+- Number of maintainers contacted.
+- Reply rate.
+- Number of maintainers who agree to a mapped task-flow example.
+- Number of projects that open a paid task or request a demo.

--- a/scrapers/github-bounty-leads.js
+++ b/scrapers/github-bounty-leads.js
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+const DEFAULT_QUERIES = [
+  '"bounty" "github" "open source"',
+  '"/bounty $"',
+  '"paid issue" "github"',
+  '"reward" "pull request"',
+  '"good first issue" "bounty"',
+  '"help wanted" "bounty"',
+]
+
+const REPO_NOISE = [
+  /(^|\/)(test|demo|sandbox|playground|practice|tutorial|learning)(-|_|$)/i,
+  /(^|\/)(fork|archive|mirror)(-|_|$)/i,
+]
+
+const TITLE_NOISE = [
+  /\btest\b/i,
+  /\bplaceholder\b/i,
+  /\bexample\b/i,
+  /\bonboarding\b/i,
+]
+
+function parseArgs(argv) {
+  const args = {
+    perQuery: 15,
+    minScore: 6,
+    format: "markdown",
+    queries: DEFAULT_QUERIES,
+  }
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i]
+    const next = argv[i + 1]
+    if (arg === "--per-query" && next) {
+      args.perQuery = Number(next)
+      i += 1
+    } else if (arg === "--min-score" && next) {
+      args.minScore = Number(next)
+      i += 1
+    } else if (arg === "--format" && next) {
+      args.format = next
+      i += 1
+    } else if (arg === "--query" && next) {
+      args.queries = [next]
+      i += 1
+    }
+  }
+
+  return args
+}
+
+function authHeaders() {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "ubiquity-github-bounty-leads",
+    "X-GitHub-Api-Version": "2022-11-28",
+  }
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+
+  return headers
+}
+
+function extractAmount(text) {
+  const matches = [...text.matchAll(/(?:\$|USD\s*)([1-9][0-9]{1,5})/gi)]
+    .map((match) => Number(match[1]))
+    .filter((amount) => Number.isFinite(amount))
+  return matches.length ? Math.max(...matches) : 0
+}
+
+function scoreIssue(issue) {
+  const text = `${issue.title}\n${issue.body ?? ""}`
+  const labels = (issue.labels ?? []).map((label) => label.name.toLowerCase())
+  const repo = issue.repository_url.replace("https://api.github.com/repos/", "")
+  const amount = extractAmount(text)
+  let score = 0
+
+  if (amount >= 20) score += 4
+  if (amount >= 100) score += 2
+  if (labels.some((label) => label.includes("bounty"))) score += 3
+  if (labels.some((label) => label.includes("good first issue") || label.includes("help wanted"))) score += 1
+  if (issue.state === "open") score += 2
+  if ((issue.comments ?? 0) <= 5) score += 2
+  if ((issue.comments ?? 0) >= 20) score -= 2
+  if (REPO_NOISE.some((pattern) => pattern.test(repo))) score -= 3
+  if (TITLE_NOISE.some((pattern) => pattern.test(issue.title))) score -= 2
+  if (/scam|airdrop|giveaway|referral/i.test(text)) score -= 5
+
+  return { amount, score }
+}
+
+async function searchIssues(query, perQuery) {
+  const url = new URL("https://api.github.com/search/issues")
+  url.searchParams.set("q", `is:issue is:open ${query}`)
+  url.searchParams.set("sort", "updated")
+  url.searchParams.set("order", "desc")
+  url.searchParams.set("per_page", String(perQuery))
+
+  const response = await fetch(url, { headers: authHeaders() })
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`GitHub search failed for ${query}: ${response.status} ${body}`)
+  }
+
+  return response.json()
+}
+
+function normalizeLead(issue, query) {
+  const repo = issue.repository_url.replace("https://api.github.com/repos/", "")
+  const { amount, score } = scoreIssue(issue)
+  return {
+    score,
+    amount,
+    title: issue.title.replace(/\s+/g, " ").trim(),
+    repo,
+    url: issue.html_url,
+    updatedAt: issue.updated_at,
+    comments: issue.comments ?? 0,
+    labels: (issue.labels ?? []).map((label) => label.name).join(", "),
+    query,
+  }
+}
+
+function dedupe(leads) {
+  const byUrl = new Map()
+  for (const lead of leads) {
+    const existing = byUrl.get(lead.url)
+    if (!existing || lead.score > existing.score) {
+      byUrl.set(lead.url, lead)
+    }
+  }
+  return [...byUrl.values()]
+}
+
+function toMarkdown(leads) {
+  const rows = [
+    "| Score | Bounty | Repo | Issue | Comments | Updated |",
+    "| ---: | ---: | --- | --- | ---: | --- |",
+  ]
+
+  for (const lead of leads) {
+    rows.push(
+      `| ${lead.score} | ${lead.amount ? `$${lead.amount}` : ""} | ${lead.repo} | [${lead.title.replaceAll("|", "\\|")}](${lead.url}) | ${lead.comments} | ${lead.updatedAt.slice(0, 10)} |`,
+    )
+  }
+
+  return rows.join("\n")
+}
+
+function csvEscape(value) {
+  return `"${String(value ?? "").replaceAll('"', '""')}"`
+}
+
+function toCsv(leads) {
+  const header = ["score", "amount", "repo", "title", "url", "comments", "updatedAt", "labels", "query"]
+  const rows = leads.map((lead) => header.map((key) => csvEscape(lead[key])).join(","))
+  return [header.join(","), ...rows].join("\n")
+}
+
+async function main() {
+  const args = parseArgs(process.argv)
+  const rawLeads = []
+
+  for (const query of args.queries) {
+    const result = await searchIssues(query, args.perQuery)
+    for (const issue of result.items ?? []) {
+      rawLeads.push(normalizeLead(issue, query))
+    }
+  }
+
+  const leads = dedupe(rawLeads)
+    .filter((lead) => lead.score >= args.minScore)
+    .sort((a, b) => b.score - a.score || b.amount - a.amount || a.comments - b.comments)
+
+  if (args.format === "csv") {
+    process.stdout.write(`${toCsv(leads)}\n`)
+  } else {
+    process.stdout.write(`${toMarkdown(leads)}\n`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message)
+  process.exitCode = 1
+})


### PR DESCRIPTION
Resolves #90.

Adds a concrete GitHub-based marketing workflow for finding projects that already use bounty language and turning them into qualified Ubiquity leads without public spam.

Changes:
- Adds `scrapers/github-bounty-leads.js`, a dependency-free GitHub issue scraper that searches bounty-related terms, deduplicates results, scores leads, and emits Markdown or CSV.
- Adds `archive/partners/github/github-based-marketing.md` with the operating workflow, scoring rationale, manual review checklist, outreach pattern, daily loop, and success metrics.

Verification:
- `node --check scrapers/github-bounty-leads.js`
- `node scrapers/github-bounty-leads.js --per-query 5 --min-score 6`
- `git diff --cached --check` before commit