### PR TITLE
docs: add Opire partnership research

### DIFF
--- a/research/opire-partnership-analysis.md
+++ b/research/opire-partnership-analysis.md
@@ -1,0 +1,328 @@
+# Opire Partnership Research and Outreach Plan
+
+**Issue:** [#89 - Opire](https://github.com/ubiquity/business-development/issues/89)
+**Prepared for:** Ubiquity business development
+**Last updated:** May 11, 2026
+**Objective:** determine whether Opire is a worthwhile partner, identify concrete collaboration paths, and provide reusable outreach assets.
+
+---
+
+## Executive Summary
+
+Opire is a GitHub-native rewards platform for open-source issues. Its positioning is very close to Ubiquity's bounty workflow: issue-first work discovery, bot-assisted GitHub commands, and payout-based contributor incentives. The strongest partnership angle is **not** replacing either system. It is a lightweight collaboration where Ubiquity uses Opire as a source of external partner projects and Opire uses Ubiquity as a crypto-native, DAO-native case study and payout/incentive design partner.
+
+**Recommendation:** pursue a low-friction partnership conversation with Opire's team, starting with a co-marketing and bounty-feed pilot before committing engineering resources.
+
+**Best first ask:** a 30-minute founder/operator call to validate three ideas:
+
+1. Cross-list selected Ubiquity bounties to Opire's developer audience.
+2. Route Opire projects that need crypto-native incentives, stablecoin payments, or DAO tooling to Ubiquity.
+3. Compare bot and bounty lifecycle design patterns to identify an integration worth building.
+
+**Why this is attractive:**
+
+- Opire already serves the same broad problem: turning GitHub issues into paid work.
+- Their website and docs emphasize that developers receive 100% of rewards, while creators pay platform/Stripe costs on top.
+- Their platform is built around GitHub bot commands plus a web app, so Ubiquity's current GitHub-centric operating model is easy for them to understand.
+- Public footprint is still early enough that a Ubiquity relationship could be meaningful rather than lost among many enterprise partners.
+
+**Primary caution:** Opire is adjacent enough to be a competitor in bounty discovery. The partnership should begin with **audience exchange and infrastructure learning**, not a deep integration that gives away Ubiquity's differentiation.
+
+---
+
+## 1. Research Snapshot
+
+### Public company and product signals
+
+- **Website:** https://opire.dev
+- **App:** https://app.opire.dev
+- **Docs:** https://docs.opire.dev
+- **GitHub organization:** https://github.com/Opire
+- **Public API base exposed by website config:** `https://api.opire.dev`
+- **Contact email in GitHub organization:** `team@opire.dev`
+- **Contact from issue intelligence:** Rubén Rüger, co-founder/CTO, `contact@rruger.dev`, GitHub `RubenRuCh`
+- **Community links exposed by current website config:** Discord, Reddit, X/Twitter, Ko-fi, GitHub, LinkedIn
+- **GitHub organization status at time of research:** 7 public repositories, 130 followers, created January 13, 2024
+
+### Product model
+
+Opire describes itself as a rewards platform for software developers. The product has two core surfaces:
+
+1. **GitHub bot:** installed on repositories so users can create rewards, claim them, and interact with Opire from GitHub.
+2. **Web platform:** used for reward discovery, search/filtering, profile configuration, reward history, and payout management.
+
+The docs describe a reward lifecycle where a reward is attached to a GitHub issue, displayed on Opire and on the issue, attempted by a developer, reviewed through the pull request process, and paid after the work is accepted.
+
+### Pricing and payout model
+
+Current public docs and website copy indicate:
+
+- Rewards are denominated in **USD**.
+- Developers receive **100% of the reward**.
+- Fees are charged on top to the reward creator.
+- Website pricing copy states Opire is free to use and charges the bounty creator **4% Opire fees + Stripe fees** when a bounty is paid out.
+- Organization and individual subscriptions unlock discounts and additional features.
+- The public pricing page explains Stripe-powered currency conversion for recipients whose bank receives a non-USD currency.
+
+### Public repository footprint
+
+Opire's public GitHub organization contains the following visible repositories:
+
+- `Opire/docs` — documentation, recently updated.
+- `Opire/website` — current website.
+- `Opire/frontend` — application frontend.
+- `Opire/design-system` — design system.
+- `Opire/.github` — community templates and organization profile.
+- `Opire/web` — old website.
+- `Opire/blog-a-thon` — campaign/event site.
+
+The organization is public enough to validate that Opire is actively maintained, but not all backend/payment infrastructure is public.
+
+---
+
+## 2. Fit With Ubiquity
+
+### Where the models overlap
+
+Both Opire and Ubiquity turn GitHub issues into paid contributor work. Both benefit from:
+
+- Clear issue scopes.
+- Bot-mediated assignment and lifecycle commands.
+- Public work history.
+- Trustworthy payout execution.
+- A reliable contributor funnel.
+
+### Where the models differ
+
+- **Opire:** a horizontal rewards marketplace for many open-source projects.
+- **Ubiquity:** a DAO operations and contribution system with crypto-native incentives, internal governance context, and an existing contributor workflow.
+- **Opire:** public materials emphasize USD and Stripe-based payment flows.
+- **Ubiquity:** can credibly discuss on-chain payments, stablecoin/crypto-native contributors, DAO accountability, and GitHub-based operations at scale.
+
+### Partnership thesis
+
+Opire and Ubiquity are close enough to understand each other immediately but different enough to exchange value. The ideal partnership is an **ecosystem bridge**:
+
+- Ubiquity gets access to additional open-source maintainers and bounty hunters.
+- Opire gets crypto/DAO expertise and a credible web3 case study.
+- Both parties can learn from each other's issue lifecycle, anti-abuse controls, and developer onboarding.
+
+---
+
+## 3. Opportunity Map
+
+### Opportunity A: Cross-promotion and bounty discovery
+
+**Concept:** cross-list selected bounties or publish a monthly bounty digest featuring both ecosystems.
+
+**Ubiquity value:** more contributors see high-value Ubiquity issues.
+**Opire value:** more reward inventory and a web3/DAO audience.
+**Effort:** low.
+**Risk:** low, if framed as a pilot.
+
+**Pilot design:**
+
+- Pick 3-5 Ubiquity issues with strong specs and clear prices.
+- Ask Opire whether they can feature them in a newsletter, Discord channel, website collection, or social post.
+- In return, Ubiquity can highlight selected Opire bounties that need web3, TypeScript, automation, or GitHub bot expertise.
+- Track clicks, applicants, attempts, and completions for 30 days.
+
+### Opportunity B: Crypto payout or stablecoin advisory
+
+**Concept:** Ubiquity helps Opire evaluate whether crypto payouts are worth supporting for developers who cannot or prefer not to receive Stripe payouts.
+
+**Ubiquity value:** positions Ubiquity as a crypto-native infrastructure partner rather than just another bounty board.
+**Opire value:** expands payout design options and opens a differentiated feature path.
+**Effort:** medium.
+**Risk:** medium due to compliance, support, and accounting complexity.
+
+**Recommended boundary:** start as a research exchange, not an implementation commitment.
+
+### Opportunity C: Shared GitHub-bot lifecycle research
+
+**Concept:** compare Opire's reward lifecycle and Ubiquity's issue lifecycle to identify best practices around assignment, completion, disputes, duplicate claims, and stale work.
+
+**Ubiquity value:** improves internal operating system design.
+**Opire value:** receives DAO-scale lessons and potential bot/plugin ideas.
+**Effort:** low to medium.
+**Risk:** low if limited to non-sensitive workflow patterns.
+
+### Opportunity D: Partner-project prospecting
+
+**Concept:** use Opire's ecosystem as a lead source for open-source projects that already understand paid issues.
+
+**Ubiquity value:** projects with existing bounty behavior are easier to pitch than cold open-source maintainers.
+**Opire value:** Ubiquity can route suitable external projects back to Opire when a neutral marketplace is a better fit.
+**Effort:** medium.
+**Risk:** medium; must avoid appearing to poach Opire's relationships.
+
+**Positioning:** "We want to collaborate around open-source funding and contributor supply," not "we want your customers."
+
+---
+
+## 4. Partner/Lead Segments Worth Monitoring
+
+Because Opire is permissionless and GitHub-native, its "partners" are best treated as an ecosystem of projects using or discussing Opire rewards rather than a fixed partner list. The most actionable lead segments are:
+
+1. **Projects with active, high-value rewards:** likely to care about contributor sourcing and workflow reliability.
+2. **Projects with recurring small rewards:** likely to need process automation and repeatable bounty operations.
+3. **Projects in web3, developer tooling, TypeScript, bots, infrastructure, or automation:** highest overlap with Ubiquity contributor strengths.
+4. **Projects that discuss payout limitations:** candidates for Ubiquity's crypto-native knowledge.
+5. **Projects that install bounty bots but struggle with triage:** candidates for Ubiquity OS lessons around specification quality and task lifecycle.
+
+Known public examples from issue research and Opire's website carousel include open-source projects in game development, Python desktop automation, Rust editor tooling, TypeScript infrastructure, and Android/mobile ecosystems. These should be refreshed before outreach because bounty values and issue status change quickly.
+
+---
+
+## 5. Competitive Landscape
+
+### Algora
+
+Algora is the closest comparison: GitHub-native bounties, a public bounty marketplace, and a polished developer experience. If Ubiquity wants marketplace-style discovery, Algora is the benchmark Opire will likely be compared against.
+
+### Gitcoin
+
+Gitcoin is broader and web3-native, with grants and ecosystem funding beyond issue bounties. It is less directly similar to Opire's GitHub issue workflow but more relevant to Ubiquity's crypto audience.
+
+### IssueHunt and other legacy bounty boards
+
+Older platforms validate the market but often feel less central to current GitHub-native workflows. Opire's advantage is being modern, simple, and focused.
+
+### Ubiquity's defensible angle
+
+Ubiquity should not pitch itself as another generic bounty marketplace. Its stronger angle is:
+
+- DAO-native operations.
+- Crypto-native incentives and payments.
+- GitHub automation for real production work.
+- Contributor accountability mechanisms.
+- End-to-end operating system rather than only reward discovery.
+
+---
+
+## 6. Recommended Partnership Plan
+
+### Phase 1: Validate interest (week 1)
+
+**Owner:** business development
+**Action:** contact Opire founders/operators with a concise partnership note.
+**Goal:** secure a 30-minute call.
+
+**Questions to validate:**
+
+- Are they open to cross-promoting external bounties?
+- Do they already support or plan to support crypto payouts?
+- Which contributor categories are currently oversupplied or undersupplied?
+- What project categories convert best on Opire?
+- Are they interested in a DAO bounty case study?
+
+### Phase 2: Run a no-code pilot (weeks 2-5)
+
+**Action:** cross-promote 3-5 issues from each ecosystem.
+
+**Success metrics:**
+
+- Number of inbound contributors.
+- Number of `/try`, assignment, claim, or equivalent attempts.
+- PRs opened.
+- Work completed and paid.
+- Discord/community engagement.
+- Qualitative contributor fit.
+
+### Phase 3: Decide whether to integrate (week 6)
+
+Only consider technical work if the no-code pilot shows signal.
+
+Potential integration candidates:
+
+- Shared bounty feed.
+- Opire listing for selected Ubiquity issues.
+- Ubiquity OS adapter or data bridge.
+- Crypto payout research memo.
+- Joint docs on bounty lifecycle best practices.
+
+### Phase 4: Formalize or exit
+
+If metrics are good, propose a simple memorandum of collaboration covering co-marketing, referral norms, and data sharing. If metrics are weak, maintain the relationship but avoid engineering spend.
+
+---
+
+## 7. Risks and Mitigations
+
+### Risk: direct competition for bounty visibility
+
+**Mitigation:** lead with complementary audiences and case studies. Do not pitch migration or replacement.
+
+### Risk: unclear ownership of external leads
+
+**Mitigation:** agree that Opire-originated projects remain Opire relationships unless they explicitly request Ubiquity/DAO services.
+
+### Risk: crypto payout complexity
+
+**Mitigation:** discuss as a research/advisory track first. Avoid promising implementation, custody, tax, or compliance support.
+
+### Risk: low conversion from cross-promotion
+
+**Mitigation:** use a small 30-day pilot with preselected, well-scoped, attractive issues.
+
+### Risk: stale bounty data
+
+**Mitigation:** refresh issue values and statuses immediately before any public outreach or PR description.
+
+---
+
+## 8. Outreach Assets
+
+### Short email / LinkedIn message
+
+Subject: Ubiquity x Opire — GitHub bounty collaboration?
+
+Hi Rubén / Opire team,
+
+I'm reaching out from Ubiquity. We operate a GitHub-native bounty and contributor workflow for DAO work, and Opire appears to be solving a closely related problem for the broader open-source ecosystem.
+
+I researched Opire for a Ubiquity business-development task and found a few collaboration ideas that look lightweight to validate:
+
+- cross-promoting selected high-quality bounties to each other's developer communities;
+- comparing GitHub bot lifecycle patterns for reward creation, assignment, claims, and completion;
+- exploring whether Ubiquity's crypto/DAO experience could help Opire projects or contributors that need stablecoin/on-chain payout options.
+
+Would you be open to a 30-minute call to compare notes and see whether a small no-code pilot makes sense?
+
+Best,
+[Name]
+
+### Discord opener
+
+Hi Opire team — I'm researching collaboration opportunities between Ubiquity and Opire. Ubiquity also runs GitHub-native paid issue workflows, with a DAO/crypto-native angle. We'd like to explore a lightweight pilot around cross-promoting selected bounties and comparing bot lifecycle best practices. Who is the best person to speak with?
+
+### Call agenda
+
+1. Quick intros and product positioning.
+2. What types of bounties/projects convert best on Opire?
+3. What contributor segments does Opire need more of?
+4. Where does Ubiquity need more contributor reach?
+5. Is crypto/stablecoin payout support strategically interesting for Opire?
+6. Choose or reject a 30-day no-code cross-promotion pilot.
+7. Define owners, success metrics, and next check-in.
+
+---
+
+## 9. PR-Ready Conclusion
+
+Opire is a relevant business-development target for Ubiquity because it is active, GitHub-native, bounty-focused, and early enough for a partnership to matter. The most practical next step is a **small cross-promotion pilot**, not immediate engineering integration. If the pilot produces qualified contributors or strong partner interest, Ubiquity can then explore deeper technical collaboration around bounty feeds, bot lifecycle patterns, or crypto-native payout research.
+
+**Recommended action:** reach out to Opire using the short message above and propose a 30-minute call plus a 30-day no-code pilot.
+
+---
+
+## Sources Checked
+
+- Opire website: https://opire.dev
+- Opire app URL exposed by website config: https://app.opire.dev
+- Opire docs: https://docs.opire.dev
+- Opire pricing docs: https://docs.opire.dev/rewards/pricing
+- Opire lifecycle docs: https://docs.opire.dev/rewards/lifecycle
+- Opire GitHub organization: https://github.com/Opire
+- Ubiquity issue #89 comments and context: https://github.com/ubiquity/business-development/issues/89
+- Closed PR #199 context: https://github.com/ubiquity/business-development/pull/199


### PR DESCRIPTION
## Summary
- Adds a researched Opire partnership analysis for issue #89.
- Covers strategic fit, partnership opportunities, competitive landscape, phased execution plan, risks/mitigations, and outreach assets.
- Includes ready-to-use outreach email, Discord opener, call agenda, and source list.

## Issue
Closes #89

## Verification
- `git diff --check`
- `git diff --stat development...HEAD`
- `git status --short --branch`
