### PR TITLE
feat: add GitHub marketing lead sprint

### DIFF
--- a/archive/partners/github/github-based-marketing-leads.md
+++ b/archive/partners/github/github-based-marketing-leads.md
@@ -1,0 +1,268 @@
+# GitHub Based Marketing: Qualified Lead Sprint
+
+Issue: [#90 GitHub Based Marketing](https://github.com/ubiquity/business-development/issues/90)
+Prepared: 2026-05-11
+Scope: convert GitHub search for `bounty`, `bug bounty`, `bounty program`, and adjacent payment-flow language into a reviewed list of prospects for UbiquityOS.
+
+## Executive summary
+
+This is an execution-oriented first sprint, not only a strategy note. I searched live GitHub issues, filtered out stale/spammy results, and turned the best current matches into a contact queue with personalized angles.
+
+Primary finding: there are two strong prospect types on GitHub right now:
+
+1. **Teams designing a bounty workflow** and asking how to document, claim, verify, or pay contributors.
+2. **Web3/agent/DAO teams already using USDC, tokens, or hackathon bounties** but still doing coordination manually.
+
+Recommended next action: contact the **top 7 leads** below with value-first comments or direct messages. Avoid generic advertisements; every message should map one visible workflow pain to one UbiquityOS capability.
+
+## Qualification method
+
+Searches run through GitHub issue search on 2026-05-11:
+
+- `"bounty program" state:open`
+- `"bug bounty program" state:open`
+- `"bounty" "USDC" state:open`
+- `"bounty" "Solana" state:open`
+- `"payment" "bounty" state:open`
+- `"claim" "bounty" "GitHub" state:open`
+
+Lead scoring:
+
+- **Workflow fit:** are they coordinating bounties, claims, payments, verification, or contributor onboarding?
+- **Ubiquity fit:** would GitHub-native incentives, pricing, task assignment, or crypto/stablecoin payouts help?
+- **Timeliness:** open issue and recently updated repository/issue.
+- **Outreach safety:** can Ubiquity add a helpful, specific comment without looking like spam?
+
+## Top outreach queue
+
+### 1. HHS/simpler-grants-gov — documentation for bounty workflow
+
+- URL: https://github.com/HHS/simpler-grants-gov/issues/10068
+- Issue: `Add Bounty Program section to CONTRIBUTING.md`
+- Repo signal: active government grant platform; issue asks for claim flow, ToS, payment mechanics, and contributor conduct.
+- Why it matters: this is a visible example of an organization formalizing bounty operations. It is not crypto-native, but it validates the market need around documented claims and payments.
+- Ubiquity angle: provide a concrete reference checklist for GitHub-native bounty sections: issue labels, assignment, claim state, reviewer approval, payout terms, and audit trail.
+- Suggested action: comment with a concise checklist and mention Ubiquity only as an example after adding value.
+- Priority: **High**
+
+Draft:
+
+```md
+This section may be easier for contributors if it separates the bounty lifecycle into explicit states:
+
+1. Eligible issues: label/name convention and where to browse them.
+2. Claiming: who can claim, how conflicts are handled, and whether assignment is required before work starts.
+3. Review: expected PR evidence, maintainer approval, and rejection/redo rules.
+4. Payment: payout provider, tax constraints, timing, and dispute path.
+5. Audit trail: link issue → PR → approval → payout record.
+
+We use a similar GitHub-native pattern at UbiquityOS for paid open-source tasks, so happy to share a compact example if useful.
+```
+
+### 2. numbersprotocol/community-support — community bounty program request
+
+- URL: https://github.com/numbersprotocol/community-support/issues/367
+- Issue: `[Community Request] Bounty Program`
+- Repo signal: open request labeled `bounty`; Numbers Protocol is Web3-adjacent and community-oriented.
+- Why it matters: they want contributors to actively find product issues and improve stability.
+- Ubiquity angle: position UbiquityOS as a GitHub-native way to turn community bug reports and feature work into priced, reviewable tasks.
+- Suggested action: ask whether they need bounty discovery, triage, claim management, or payout automation first; offer a small pilot workflow.
+- Priority: **High**
+
+Draft:
+
+```md
+A lightweight way to launch this without creating a separate platform is to keep the bounty lifecycle in GitHub:
+
+- `bounty` label for eligible requests
+- price label or issue body field for reward size
+- assignment/claim rule before work starts
+- PR linked to the issue as proof of completion
+- maintainer approval comment as the payout trigger
+
+UbiquityOS is built around this GitHub-native model for paid open-source tasks. If the team is exploring tooling, a small pilot could start with 3-5 low-risk product issues before expanding to security-sensitive reports.
+```
+
+### 3. ds1/pincerpay — Solana/AI agent hackathon bounties
+
+- URL: https://github.com/ds1/pincerpay/issues/96
+- Issue: `Hackathon bounty program`
+- Repo signal: on-chain USDC payment gateway for AI agents; issue describes $250-$500 USDC bounties and case studies.
+- Why it matters: this is a direct match for crypto payout operations plus developer acquisition.
+- Ubiquity angle: help publish and manage bounty tracks as GitHub issues, then use PRs/integration demos as proof of completion.
+- Suggested action: offer a co-marketing style workflow: GitHub bounty issue template + automated winner evidence collection.
+- Priority: **High**
+
+Draft:
+
+```md
+For hackathon bounties, GitHub issues can double as the public source of truth:
+
+- one issue per bounty track
+- required submission checklist in the issue body
+- links to demo repo, integration PR, and transaction evidence
+- maintainer approval comment before payout
+- follow-up case-study template after acceptance
+
+This overlaps with how UbiquityOS coordinates paid GitHub tasks. If helpful, I can outline a minimal bounty issue template for the PincerPay USDC-agent-payment tracks.
+```
+
+### 4. cenetex/signal — game economy and permissionless bounty contracts
+
+- URL: https://github.com/cenetex/signal/issues/480
+- Issue: `decentralization (Solana): state-root anchoring, wrap contract, bounty program`
+- Repo signal: active game repo; issue explicitly mentions permissionless bounty contracts and `100 USDC` asset-delivery use cases.
+- Why it matters: strong conceptual fit for on-chain bounty mechanics, although the project is early.
+- Ubiquity angle: GitHub can coordinate the off-chain task specification/review layer while contracts handle settlement.
+- Suggested action: comment with an architecture note separating task definition, proof, review, and payout settlement.
+- Priority: **High / experimental**
+
+Draft:
+
+```md
+One useful split for the bounty portion may be:
+
+- GitHub issue: human-readable task spec, acceptance criteria, and discussion.
+- Game proof: signed event/state evidence for the delivered asset.
+- Reviewer step: maintainer or oracle confirms the proof satisfies the issue.
+- Settlement: contract releases the USDC/token payout.
+
+That separation keeps the bounty understandable to contributors while still allowing on-chain settlement. UbiquityOS uses a similar GitHub-first task coordination model, so this may be a good place to borrow patterns from paid OSS workflows.
+```
+
+### 5. RWATokens/public — new bug bounty program issue
+
+- URL: https://github.com/RWATokens/public/issues/30
+- Issue: `Bug bounty program`
+- Repo signal: Solana Token-2022/RWA infrastructure; repo recently pushed.
+- Why it matters: crypto/security-sensitive project likely needs clear triage and payout rules before accepting reports.
+- Ubiquity angle: offer a bounty-program issue template and GitHub label taxonomy; do not imply Ubiquity replaces security platforms for critical vulnerabilities.
+- Suggested action: value-first comment with a safe launch checklist.
+- Priority: **Medium-high**
+
+Draft:
+
+```md
+Before opening this broadly, it may help to define:
+
+- in-scope repos/contracts and out-of-scope reports
+- severity bands and payout ranges
+- private disclosure path for critical issues
+- duplicate-report rules
+- expected response SLA
+- public GitHub tracking only for non-sensitive program/admin tasks
+
+For non-sensitive improvement bounties, a GitHub-native workflow like UbiquityOS can handle issue pricing, claims, PR evidence, and payout approvals. For critical security reports, keep private disclosure separate.
+```
+
+### 6. sint-ai/sint-protocol — roadmap item to launch bug bounty program
+
+- URL: https://github.com/sint-ai/sint-protocol/issues/72
+- Issue: `Q3: Launch bug bounty program`
+- Repo signal: AI-agent governance/safety protocol; open roadmap item with implementation/docs acceptance criteria.
+- Why it matters: early enough to influence their bounty design before tooling decisions are made.
+- Ubiquity angle: paid GitHub tasks for docs, tests, and implementation bounties; separate from private vulnerability reports.
+- Suggested action: comment with a two-lane bounty model: public implementation bounties and private security reports.
+- Priority: **Medium-high**
+
+Draft:
+
+```md
+A practical launch model is two lanes:
+
+1. Public GitHub bounties for docs, tests, examples, and non-sensitive implementation tasks.
+2. Private security reports for vulnerabilities until triaged.
+
+For lane 1, GitHub-native tooling can make the process simple: price label, claim/assignment rule, linked PR, review approval, and payout record. UbiquityOS is one example of this pattern for paid open-source tasks.
+```
+
+### 7. parse-community/Governance — bounty claim verification thread
+
+- URL: https://github.com/parse-community/Governance/issues/18
+- Issue: `Parse Bounty Program - User Verification`
+- Repo signal: established OSS community; thread verifies submitted Open Collective expense claims.
+- Why it matters: they already have a bounty program and a manual identity/claim verification step.
+- Ubiquity angle: suggest reducing manual verification friction by linking issue, PR, approval, and claimant identity in one auditable chain.
+- Suggested action: open a non-sales comment only if it includes a concrete workflow improvement.
+- Priority: **Medium**
+
+Draft:
+
+```md
+For future claim verification, it may help to standardize each claim around one compact evidence bundle:
+
+- bounty issue URL
+- accepted PR URL
+- maintainer approval comment URL
+- claimant GitHub handle
+- payout request URL
+
+That gives reviewers a single chain to audit. UbiquityOS automates a similar issue → PR → approval → reward flow for paid OSS tasks, and the same structure may reduce manual verification overhead here.
+```
+
+## Secondary leads to watch
+
+### Lissy93/bug-bounties
+
+- URL: https://github.com/Lissy93/bug-bounties/issues/53
+- Signal: active directory of responsible-disclosure and bounty programs.
+- Use carefully: this is more of a directory/data source than a buyer. Good for monitoring new bounty programs, not for direct Ubiquity pitching on every submission.
+- Action: watch recent submissions weekly and extract organizations that are starting programs.
+
+### CosmWasm/cosmwasm
+
+- URL: https://github.com/CosmWasm/cosmwasm/issues/2630
+- Signal: strong Web3 repo, but issue points to HackerOne and is not requesting GitHub workflow tooling.
+- Action: do not comment unless there is a separate public bounty/process issue.
+
+### tatiana-mintycode/MintycodeEcosystem
+
+- URL: https://github.com/tatiana-mintycode/MintycodeEcosystem/issues/5
+- Signal: bounty/platform language, but appears to promote another bounty search flow.
+- Action: monitor only; low priority for outreach.
+
+### PetroSilenius/literally-everything-you-need-to-do-as-a-startup-cto
+
+- URL: https://github.com/PetroSilenius/literally-everything-you-need-to-do-as-a-startup-cto/issues/106
+- Signal: generic startup checklist item.
+- Action: low priority; could contribute generic bounty-program guidance if the repo becomes active.
+
+## Reusable non-spam outreach rules
+
+Use these guardrails for every GitHub comment:
+
+- Start with a concrete observation from the issue.
+- Provide a checklist, template, or architecture note before mentioning Ubiquity.
+- Mention Ubiquity once, as an example or offer, not as the whole comment.
+- Avoid commenting on vulnerability reports or private-security workflows with marketing copy.
+- Do not post the same message twice.
+- Stop after one comment unless the maintainer replies.
+
+## Daily operating loop
+
+1. Run the search set above.
+2. Add new matches to a lead sheet with: repo, issue, fit, risk, recommended message, owner, date contacted, response.
+3. Qualify only open issues updated in the last 90 days unless the repo is strategically important.
+4. Draft a personalized comment for each high-fit lead.
+5. Have a human reviewer approve comments before posting.
+6. Track response types:
+   - interested in UbiquityOS
+   - asked for example/template
+   - no response after 7 days
+   - not a fit
+   - asked not to contact
+
+## Success metrics for the next 14 days
+
+- 20 qualified leads reviewed.
+- 7 personalized comments or direct messages sent.
+- 3 maintainer replies.
+- 1 scheduled product discussion or pilot candidate.
+- 1 reusable bounty-program template derived from maintainer feedback.
+
+## PR handoff checklist
+
+- This file is the first reviewed lead queue for issue #90.
+- It contains live GitHub leads, priority order, and ready-to-edit outreach drafts.
+- No public comments were posted by this PR; comments should be approved by Ubiquity before outreach.
+- Next PR can add a lightweight lead tracker CSV or automation only after this manual messaging loop validates which searches convert.


### PR DESCRIPTION
## Summary
- Adds a GitHub-based marketing lead sprint for issue #90.
- Includes a repeatable GitHub search method, prioritized outreach queue, personalized outreach drafts, non-spam guardrails, daily operating loop, and 14-day success metrics.
- Focuses on actionable outreach targets rather than a generic strategy document.

## Issue
Closes #90

## Verification
- `git diff --check`
- `git diff --stat development...HEAD`
- `git status --short --branch`
