### PR TITLE
feat: add DoraHacks bounty post for UbiquityDAO (#174)

### DIFF
--- a/dorahacks/ubiquity-dao-bounty.md
+++ b/dorahacks/ubiquity-dao-bounty.md
@@ -1,0 +1,40 @@
+# 🚀 Ubiquity DAO — Newcomer's Bounty
+
+This DoraHacks Newcomer's Bounty is brought to you by **Ubiquity DAO**.
+
+We have ready-to-start tasks available 24/7 in the [devpool.directory](https://devpool.directory/) where participants can collaborate asynchronously, leveraging our automated Permit2-based payment system.
+
+## 🌟 About UbiquityOS
+
+**UbiquityOS** delivers AI-powered performance analytics for your software engineering team. While GitHub provides surface-level metrics like commit counts and pull requests, UbiquityOS goes deeper — measuring true engineering impact and productivity through automated, qualitative insights.
+
+Our core offering is straightforward: performance analytics for your software engineering team.
+
+## 🎯 Available Tasks
+
+### Task 1: Build a Plugin
+Create a custom UbiquityOS plugin that extends our automation platform. Choose from our plugin wishlist or propose your own idea.
+
+### Task 2: Build DevTools
+Contribute to our developer tooling ecosystem — bot commands, integrations, and automation workflows.
+
+### Task 3: Wildcard
+Have an idea that doesn't fit the above? Propose it! We're always open to creative contributions.
+
+## 💰 Rewards
+- **Bounty Pool**: Spread across multiple winners
+- **Bonus**: Any participant who successfully gets a PR merged qualifies for an additional reward on top of their task payout
+- Payments handled via Ubiquity's automated Permit2-based system
+
+## 📋 Submission Rules
+1. Fork the relevant repository
+2. Complete the task following our contribution guidelines
+3. Submit a Pull Request linking back to this bounty
+4. PRs will be reviewed after the submission deadline
+
+## 🔗 Resources
+- [DevPool Directory](https://devpool.directory/)
+- [UbiquityOS](https://github.com/ubiquity/ubiquity-os)
+- [DoraHacks Bounty Guide](https://dorahacks.io/blog/guides/publish-a-bounty/)
+
+Let's build the future of decentralized development together! 🚀


### PR DESCRIPTION
## Summary
This PR adds a DoraHacks bounty post for UbiquityDAO, as requested in issue #174.

## Changes
- Created `dorahacks/ubiquity-dao-bounty.md` with the bounty post template
- Focuses on UbiquityOS as the core offering
- Incorporates the 2025 Marketing Narrative
- Includes 3 task categories: Build a Plugin, Build DevTools, Wildcard
- Includes submission rules and reward structure

## References
- Closes #174
- Based on previous successful post from #116