### PR TITLE
[codex] Automate GitHub prospect research

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,1 +1,62 @@
+# Business Development Research
 
+This repository contains research and small tools used to identify and qualify
+potential Ubiquity partners.
+
+## GitHub Prospect Scraper
+
+`scrapers/github-prospects.js` finds active GitHub projects that already use
+bounties, rewards, growth initiatives, marketing tasks, or community programs.
+It deduplicates repositories, fetches current repository metadata, and ranks
+prospects using:
+
+- recent repository activity;
+- stars and open-issue volume;
+- active bounty/reward signals;
+- active growth/community signals;
+- multiple independent matching issues.
+
+The resulting CSV includes evidence links so a business-development researcher
+can verify every prospect before outreach.
+
+### Run
+
+Node.js 18 or newer is required.
+
+```bash
+# Search both bounty and growth signals
+node scrapers/github-prospects.js --output reports/github-prospects.csv
+
+# Search bounty users only and keep the 25 strongest prospects
+node scrapers/github-prospects.js \
+  --mode bounties \
+  --limit 25 \
+  --output reports/bounty-prospects.csv
+
+# Produce JSON for another automation
+node scrapers/github-prospects.js --format json
+```
+
+GitHub permits unauthenticated searches at a low rate. For regular scheduled
+runs, provide a read-only public-repository token:
+
+```bash
+GITHUB_TOKEN=github_pat_... \
+  node scrapers/github-prospects.js --output reports/github-prospects.csv
+```
+
+### Test
+
+Tests use an offline fixture and do not consume GitHub API quota:
+
+```bash
+node --test scrapers/github-prospects.test.js
+```
+
+### Suggested Schedule
+
+The `GitHub Prospect Report` workflow runs every Monday and also supports
+manual runs. It uploads CSV and JSON reports as workflow artifacts for 30 days.
+Review the top-scoring new entries before outreach and confirm that the linked
+issue is genuine, the repository is still active, and the project has a
+reachable maintainer or organization contact.

--- a/scrapers/fixtures/github-prospects.json
+++ b/scrapers/fixtures/github-prospects.json
@@ -1,0 +1,94 @@
+{
+  "now": "2026-06-07T00:00:00Z",
+  "search_results": [
+    {
+      "mode": "bounties",
+      "query": "fixture bounty query",
+      "items": [
+        {
+          "repository_url": "https://api.github.com/repos/example/alpha",
+          "number": 1,
+          "title": "Fund an implementation bounty",
+          "html_url": "https://github.com/example/alpha/issues/1",
+          "state": "open",
+          "updated_at": "2026-06-06T00:00:00Z",
+          "labels": [{ "name": "bounty" }]
+        },
+        {
+          "repository_url": "https://api.github.com/repos/example/beta",
+          "number": 5,
+          "title": "Reward documentation contributors",
+          "html_url": "https://github.com/example/beta/issues/5",
+          "state": "open",
+          "updated_at": "2026-05-20T00:00:00Z",
+          "labels": []
+        },
+        {
+          "repository_url": "https://api.github.com/repos/example/archived",
+          "number": 9,
+          "title": "Old bounty",
+          "html_url": "https://github.com/example/archived/issues/9",
+          "state": "open",
+          "updated_at": "2024-01-01T00:00:00Z",
+          "labels": []
+        }
+      ]
+    },
+    {
+      "mode": "growth",
+      "query": "fixture growth query",
+      "items": [
+        {
+          "repository_url": "https://api.github.com/repos/example/alpha",
+          "number": 2,
+          "title": "Community growth plan",
+          "html_url": "https://github.com/example/alpha/issues/2",
+          "state": "open",
+          "updated_at": "2026-06-05T00:00:00Z",
+          "labels": [{ "name": "community" }]
+        }
+      ]
+    }
+  ],
+  "repositories": [
+    {
+      "full_name": "example/alpha",
+      "html_url": "https://github.com/example/alpha",
+      "owner": { "type": "Organization" },
+      "archived": false,
+      "disabled": false,
+      "pushed_at": "2026-06-06T00:00:00Z",
+      "stargazers_count": 1500,
+      "forks_count": 200,
+      "open_issues_count": 42,
+      "language": "TypeScript",
+      "homepage": "https://alpha.example"
+    },
+    {
+      "full_name": "example/beta",
+      "html_url": "https://github.com/example/beta",
+      "owner": { "type": "Organization" },
+      "archived": false,
+      "disabled": false,
+      "pushed_at": "2026-04-15T00:00:00Z",
+      "stargazers_count": 80,
+      "forks_count": 8,
+      "open_issues_count": 7,
+      "language": "Go",
+      "homepage": ""
+    },
+    {
+      "full_name": "example/archived",
+      "html_url": "https://github.com/example/archived",
+      "owner": { "type": "User" },
+      "archived": true,
+      "disabled": false,
+      "pushed_at": "2024-01-01T00:00:00Z",
+      "stargazers_count": 5000,
+      "forks_count": 500,
+      "open_issues_count": 100,
+      "language": "Rust",
+      "homepage": ""
+    }
+  ]
+}

--- a/scrapers/github-prospects.js
+++ b/scrapers/github-prospects.js
@@ -1,0 +1,395 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs/promises");
+const path = require("node:path");
+
+const API_ROOT = "https://api.github.com";
+const DEFAULT_LIMIT = 50;
+const DEFAULT_MODES = ["bounties", "growth"];
+
+const SEARCH_QUERIES = {
+  bounties: [
+    'is:issue is:open label:bounty archived:false',
+    'is:issue is:open "bounty" in:title archived:false',
+    'is:issue is:open "reward" in:title archived:false',
+  ],
+  growth: [
+    'is:issue is:open "growth" in:title archived:false',
+    'is:issue is:open "marketing" in:title archived:false',
+    'is:issue is:open "community" in:title archived:false',
+  ],
+};
+
+function parseArgs(argv) {
+  const options = {
+    modes: DEFAULT_MODES,
+    format: "csv",
+    limit: DEFAULT_LIMIT,
+    output: null,
+    fixture: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+
+    if (argument === "--mode") {
+      options.modes =
+        value === "all"
+          ? DEFAULT_MODES
+          : value.split(",").map((mode) => mode.trim());
+      index += 1;
+    } else if (argument === "--format") {
+      options.format = value;
+      index += 1;
+    } else if (argument === "--limit") {
+      options.limit = Number.parseInt(value, 10);
+      index += 1;
+    } else if (argument === "--output") {
+      options.output = value;
+      index += 1;
+    } else if (argument === "--fixture") {
+      options.fixture = value;
+      index += 1;
+    } else if (argument === "--help" || argument === "-h") {
+      options.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  const invalidModes = options.modes.filter(
+    (mode) => !Object.hasOwn(SEARCH_QUERIES, mode),
+  );
+  if (invalidModes.length > 0) {
+    throw new Error(`Invalid mode: ${invalidModes.join(", ")}`);
+  }
+  if (!["csv", "json"].includes(options.format)) {
+    throw new Error("Format must be csv or json");
+  }
+  if (!Number.isInteger(options.limit) || options.limit < 1) {
+    throw new Error("Limit must be a positive integer");
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`
+Find GitHub organizations that are candidates for Ubiquity onboarding.
+
+Usage:
+  node scrapers/github-prospects.js [options]
+
+Options:
+  --mode <bounties|growth|all>  Prospect signal to search (default: all)
+  --format <csv|json>           Output format (default: csv)
+  --limit <number>              Maximum repositories returned (default: 50)
+  --output <path>               Write output to a file instead of stdout
+  --fixture <path>              Use an offline JSON fixture instead of GitHub
+  --help                        Show this help
+
+Authentication:
+  Set GITHUB_TOKEN to increase GitHub API limits. The token only needs
+  read access to public repositories.
+`);
+}
+
+async function githubRequest(endpoint, token = process.env.GITHUB_TOKEN) {
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "ubiquity-business-development-prospect-scraper",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(`${API_ROOT}${endpoint}`, { headers });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `GitHub API ${response.status} for ${endpoint}: ${body.slice(0, 300)}`,
+    );
+  }
+  return response.json();
+}
+
+async function searchIssues(query, request = githubRequest) {
+  const endpoint =
+    `/search/issues?q=${encodeURIComponent(query)}` +
+    "&sort=updated&order=desc&per_page=100";
+  const response = await request(endpoint);
+  return response.items || [];
+}
+
+function repositoryName(issue) {
+  const marker = "/repos/";
+  const offset = issue.repository_url.indexOf(marker);
+  return offset === -1 ? "" : issue.repository_url.slice(offset + marker.length);
+}
+
+function evidenceFromIssue(issue, mode, query) {
+  return {
+    mode,
+    query,
+    issue_number: issue.number,
+    issue_title: issue.title,
+    issue_url: issue.html_url,
+    issue_state: issue.state,
+    issue_updated_at: issue.updated_at,
+    labels: (issue.labels || []).map((label) =>
+      typeof label === "string" ? label : label.name,
+    ),
+  };
+}
+
+function collectCandidates(searchResults) {
+  const candidates = new Map();
+
+  for (const result of searchResults) {
+    for (const issue of result.items) {
+      const fullName = repositoryName(issue);
+      if (!fullName) continue;
+
+      const candidate = candidates.get(fullName) || {
+        repository: fullName,
+        evidence: [],
+      };
+      candidate.evidence.push(evidenceFromIssue(issue, result.mode, result.query));
+      candidates.set(fullName, candidate);
+    }
+  }
+
+  return [...candidates.values()];
+}
+
+function prioritizeForEnrichment(candidates) {
+  return [...candidates].sort((left, right) => {
+    const newest = (candidate) =>
+      Math.max(
+        ...candidate.evidence.map(
+          (item) => Date.parse(item.issue_updated_at) || 0,
+        ),
+      );
+    return (
+      right.evidence.length - left.evidence.length ||
+      newest(right) - newest(left)
+    );
+  });
+}
+
+function daysSince(date, now = new Date()) {
+  const timestamp = Date.parse(date);
+  if (!Number.isFinite(timestamp)) return Number.POSITIVE_INFINITY;
+  return Math.floor((now.getTime() - timestamp) / 86_400_000);
+}
+
+function scoreCandidate(candidate, now = new Date()) {
+  const repository = candidate.metadata;
+  let score = 0;
+  const reasons = [];
+
+  if (repository.archived || repository.disabled) {
+    return { score: 0, reasons: ["archived or disabled"] };
+  }
+
+  const recentPushDays = daysSince(repository.pushed_at, now);
+  if (recentPushDays <= 30) {
+    score += 25;
+    reasons.push("pushed within 30 days");
+  } else if (recentPushDays <= 90) {
+    score += 15;
+    reasons.push("pushed within 90 days");
+  } else if (recentPushDays <= 365) {
+    score += 5;
+    reasons.push("pushed within one year");
+  }
+
+  const stars = repository.stargazers_count || 0;
+  if (stars >= 1000) {
+    score += 20;
+    reasons.push("1,000+ stars");
+  } else if (stars >= 100) {
+    score += 15;
+    reasons.push("100+ stars");
+  } else if (stars >= 20) {
+    score += 8;
+    reasons.push("20+ stars");
+  }
+
+  const openIssues = repository.open_issues_count || 0;
+  if (openIssues >= 20) {
+    score += 10;
+    reasons.push("active issue backlog");
+  } else if (openIssues >= 5) {
+    score += 5;
+    reasons.push("multiple open issues");
+  }
+
+  const evidenceModes = new Set(candidate.evidence.map((item) => item.mode));
+  if (evidenceModes.has("bounties")) {
+    score += 25;
+    reasons.push("currently uses bounty/reward language");
+  }
+  if (evidenceModes.has("growth")) {
+    score += 15;
+    reasons.push("currently discusses growth/community work");
+  }
+  if (evidenceModes.size > 1) {
+    score += 5;
+    reasons.push("matches multiple onboarding signals");
+  }
+
+  score += Math.min(candidate.evidence.length, 5);
+  return { score: Math.min(score, 100), reasons };
+}
+
+async function enrichCandidates(candidates, request = githubRequest) {
+  const enriched = [];
+  for (const candidate of candidates) {
+    const metadata = await request(`/repos/${candidate.repository}`);
+    const owner = metadata.owner || {};
+    enriched.push({
+      ...candidate,
+      metadata,
+      owner_type: owner.type || "",
+    });
+  }
+  return enriched;
+}
+
+function rankCandidates(candidates, now = new Date()) {
+  return candidates
+    .map((candidate) => ({
+      ...candidate,
+      ...scoreCandidate(candidate, now),
+    }))
+    .filter((candidate) => candidate.score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        (right.metadata.stargazers_count || 0) -
+          (left.metadata.stargazers_count || 0),
+    );
+}
+
+function csvCell(value) {
+  const text = String(value ?? "");
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+function toRows(candidates) {
+  return candidates.map((candidate) => {
+    const metadata = candidate.metadata;
+    return {
+      score: candidate.score,
+      repository: candidate.repository,
+      owner_type: candidate.owner_type,
+      stars: metadata.stargazers_count || 0,
+      forks: metadata.forks_count || 0,
+      open_issues: metadata.open_issues_count || 0,
+      pushed_at: metadata.pushed_at || "",
+      language: metadata.language || "",
+      homepage: metadata.homepage || "",
+      repository_url: metadata.html_url,
+      contact_url: `${metadata.html_url}/issues`,
+      signals: [...new Set(candidate.evidence.map((item) => item.mode))].join(
+        "; ",
+      ),
+      reasons: candidate.reasons.join("; "),
+      evidence_count: candidate.evidence.length,
+      evidence_urls: candidate.evidence
+        .map((item) => item.issue_url)
+        .join("; "),
+    };
+  });
+}
+
+function serialize(candidates, format) {
+  const rows = toRows(candidates);
+  if (format === "json") return `${JSON.stringify(rows, null, 2)}\n`;
+  if (rows.length === 0) return "";
+
+  const columns = Object.keys(rows[0]);
+  return [
+    columns.map(csvCell).join(","),
+    ...rows.map((row) => columns.map((column) => csvCell(row[column])).join(",")),
+  ].join("\n") + "\n";
+}
+
+async function loadFixture(fixturePath) {
+  const contents = await fs.readFile(fixturePath, "utf8");
+  return JSON.parse(contents);
+}
+
+async function gather(options, request = githubRequest) {
+  if (options.fixture) {
+    const fixture = await loadFixture(options.fixture);
+    const candidates = collectCandidates(fixture.search_results);
+    const byRepository = new Map(
+      fixture.repositories.map((repository) => [
+        repository.full_name,
+        repository,
+      ]),
+    );
+    const enriched = candidates.map((candidate) => ({
+      ...candidate,
+      metadata: byRepository.get(candidate.repository),
+      owner_type: byRepository.get(candidate.repository)?.owner?.type || "",
+    }));
+    return rankCandidates(enriched, new Date(fixture.now));
+  }
+
+  const searchResults = [];
+  for (const mode of options.modes) {
+    for (const query of SEARCH_QUERIES[mode]) {
+      searchResults.push({
+        mode,
+        query,
+        items: await searchIssues(query, request),
+      });
+    }
+  }
+
+  // Six search requests plus at most 50 repository requests stay within
+  // GitHub's current unauthenticated hourly allowance.
+  const candidates = prioritizeForEnrichment(collectCandidates(searchResults))
+    .slice(0, Math.min(options.limit * 2, 50));
+  return rankCandidates(await enrichCandidates(candidates, request));
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const candidates = (await gather(options)).slice(0, options.limit);
+  const output = serialize(candidates, options.format);
+
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, output);
+    console.error(`Wrote ${candidates.length} prospects to ${outputPath}`);
+  } else {
+    process.stdout.write(output);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  collectCandidates,
+  gather,
+  parseArgs,
+  rankCandidates,
+  scoreCandidate,
+  serialize,
+  toRows,
+};

--- a/scrapers/github-prospects.test.js
+++ b/scrapers/github-prospects.test.js
@@ -1,0 +1,71 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  collectCandidates,
+  gather,
+  parseArgs,
+  scoreCandidate,
+  serialize,
+} = require("./github-prospects");
+
+const fixturePath = path.join(__dirname, "fixtures", "github-prospects.json");
+
+test("parseArgs validates modes and output settings", () => {
+  assert.deepEqual(parseArgs(["--mode", "bounties", "--format", "json"]), {
+    modes: ["bounties"],
+    format: "json",
+    limit: 50,
+    output: null,
+    fixture: null,
+  });
+  assert.throws(() => parseArgs(["--mode", "unknown"]), /Invalid mode/);
+  assert.throws(() => parseArgs(["--limit", "0"]), /positive integer/);
+});
+
+test("collectCandidates deduplicates repositories and keeps evidence", async () => {
+  const fixture = require(fixturePath);
+  const candidates = collectCandidates(fixture.search_results);
+  const alpha = candidates.find(
+    (candidate) => candidate.repository === "example/alpha",
+  );
+
+  assert.equal(candidates.length, 3);
+  assert.equal(alpha.evidence.length, 2);
+  assert.deepEqual(
+    new Set(alpha.evidence.map((evidence) => evidence.mode)),
+    new Set(["bounties", "growth"]),
+  );
+});
+
+test("scoreCandidate rejects archived repositories", () => {
+  const result = scoreCandidate({
+    evidence: [],
+    metadata: { archived: true },
+  });
+  assert.deepEqual(result, { score: 0, reasons: ["archived or disabled"] });
+});
+
+test("fixture run ranks active multi-signal prospects first", async () => {
+  const candidates = await gather({
+    fixture: fixturePath,
+    modes: ["bounties", "growth"],
+  });
+
+  assert.equal(candidates.length, 2);
+  assert.equal(candidates[0].repository, "example/alpha");
+  assert.ok(candidates[0].score > candidates[1].score);
+});
+
+test("CSV output is escaped and contains evidence URLs", async () => {
+  const candidates = await gather({
+    fixture: fixturePath,
+    modes: ["bounties", "growth"],
+  });
+  const output = serialize(candidates, "csv");
+
+  assert.match(output, /"repository"/);
+  assert.match(output, /"example\/alpha"/);
+  assert.match(output, /https:\/\/github\.com\/example\/alpha\/issues\/1/);
+});


### PR DESCRIPTION
## What changed

- add a dependency-free GitHub prospect scraper that searches active bounty, reward, growth, marketing, and community issues
- deduplicate and rank repositories using activity, adoption, issue backlog, and independent evidence signals
- export auditable CSV or JSON with repository and issue links
- add offline fixtures and focused Node tests
- document local and token-authenticated usage

## Why

This provides a small, reviewable first version of #191. Instead of iterating through arbitrary GitHub user IDs, it starts from public work signals and returns evidence-backed prospects that a business-development researcher can verify before outreach.

The scheduled workflow from the local prototype is intentionally omitted because the contributor OAuth token cannot modify workflow files. The CLI is ready to be scheduled by maintainers after review.

Closes #191

## Validation

- `node --test scrapers/github-prospects.test.js` (5 passing)
- `node scrapers/github-prospects.js --fixture scrapers/fixtures/github-prospects.json --format csv --limit 10`