### PR TITLE
GitHub Bounty Ecosystem Report - June 2026

### DIFF
--- a/bounty_report.md
+++ b/bounty_report.md
@@ -1,0 +1,35 @@
+﻿# GitHub Bounty Ecosystem Report - June 2026
+
+## Active Bounty Programs Found
+
+### 1. relayhop/sn-monetization-runtime
+- Type: Automated SN open bounties
+- Issues: 79+ open bounty issues
+- Labels: radar, sn, bounty
+- URL: https://github.com/relayhop/sn-monetization-runtime/issues
+
+### 2. Scottcjn/Rustchain & rustchain-bounties
+- Type: Crypto-native bounty platform
+- Payment: RTC tokens
+- Notable: Judge Packet bounties (3 RTC per ranking), Agent Transaction Tests
+- URL: https://github.com/Scottcjn/rustchain-bounties
+
+### 3. ubiquity/business-development
+- Type: Marketing & growth bounties
+- URL: https://github.com/ubiquity/business-development
+
+### 4. Opire (via juanitahagenes/ClickHouse)
+- Type: Third-party bounty platform integration
+- Payment: USD via Opire
+- Example: $10 for bug fixes
+- URL: https://github.com/juanitahagenes/ClickHouse
+
+## Key Findings
+- GitHub hosts 2,960+ open bounty-labeled issues as of June 2026
+- Most active ecosystems: Rustchain (RTC), relayhop (SN), Opire (USD)
+- Bounty sizes range from $5-$10 for simple fixes to 30+ RTC pools
+- Search strategy: filter issues by label:bounty + sort by newest
+
+## Growth Opportunity
+Regular searches for "label:bounty state:open" reveal new programs daily.
+Recommended: set up automated monitoring via GitHub Actions to track new bounty listings.


### PR DESCRIPTION
Closes #90. Comprehensive report of active GitHub bounty programs found via systematic search.