### PR TITLE
feat: add Q3 2026 DoraHacks bounty post

### DIFF
--- a/docs/dorahacks/q3-2026-bounty.md
+++ b/docs/dorahacks/q3-2026-bounty.md
@@ -1,0 +1,25 @@
+# DoraHacks Bounty: Ubiquity OS Ecosystem Q3 2026
+
+## Overview
+A bounty for developers to contribute to the Ubiquity OS ecosystem, focusing on plugin development, tooling improvements, and protocol integrations.
+
+## Bounty Details
+- **Platform**: DoraHacks
+- **Organization**: Ubiquity DAO
+- **Total Rewards**: To be determined based on submissions
+- **Deadline**: Open-ended (rolling submissions)
+
+## Scope
+Developers are invited to contribute to:
+1. **Plugin Development**: Build new plugins for the Ubiquity OS ecosystem
+2. **Tooling Improvements**: Enhance developer tools, CLI, and SDKs
+3. **Protocol Integrations**: Integrate with additional DeFi protocols
+4. **Documentation**: Improve developer documentation and tutorials
+
+## How to Participate
+1. Visit https://dorahacks.io/bounty/ubiquity-dao/
+2. Submit your project through the DoraHacks platform
+3. The Ubiquity DAO team will review and reward submissions
+
+## Previous Bounties
+See https://dorahacks.io/bounty/ubiquity-dao/ for past and current bounties.


### PR DESCRIPTION
Closes #174

Adds the Q3 2026 DoraHacks bounty announcement for the Ubiquity DAO.

Content based on the previous DoraHacks bounty template at https://dorahacks.io/bounty/ubiquity-dao/