### PR TITLE
Proposal: GitHub-Based Marketing Strategy (#90)

### DIFF
--- a/STRATEGY_GITHUB_MARKETING.md
+++ b/STRATEGY_GITHUB_MARKETING.md
@@ -1,0 +1,52 @@
+# GitHub-Based Marketing Strategy for UbiquityDAO & Ubiquibot
+
+## Executive Summary
+This document outlines a targeted, developer-centric marketing strategy leveraging GitHub's native ecosystem (Search API, Issue Tracking, and Public Repositories) to identify, engage, and onboard open-source projects, DAOs, and Web3 organizations to Ubiquibot.
+
+---
+
+## 1. Target Audience Identification
+To maximize conversion and minimize friction, the automated discovery process targets three core segments:
+
+1. **Active Bounty Issuers**: Repositories actively using bounty platforms (e.g., Algora, Polar, OpenCollective, Bountysource) or tagging issues with `bounty`, `reward`, `$`.
+2. **Growing Web3 & Open-Source DAOs**: Repositories with >10 contributors and high issue throughput requiring automated task management and reward distribution.
+3. **Developer-Facing Infrastructure Tools**: High-velocity repositories looking to incentivize external contributions for bug fixes and feature enhancements.
+
+---
+
+## 2. Automated Discovery Pipeline (GitHub Search API)
+
+### Targeted Query Patterns
+- `is:issue is:open label:bounty`
+- `is:issue is:open "bounty$"`
+- `"looking for contributors" label:"help wanted"`
+- `filename:ubiquibot.config.yml` (for competitor or adoption analysis)
+
+### Automated Ranking Algorithm
+Repositories are scored based on:
+- **Activity**: Recent commit within last 14 days (+30 pts)
+- **Open Issues**: >20 open issues (+20 pts)
+- **Contributor Density**: >5 active contributors (+20 pts)
+- **Existing Bounty Usage**: Label matching (+30 pts)
+
+---
+
+## 3. High-Conversion Outreach Workflow
+
+To maintain strict compliance with GitHub's Terms of Service and avoid spam filters:
+
+1. **Contextual Issue Value Contribution**: Identify open bounty discussions and provide structured, high-value comments demonstrating Ubiquibot's automated escrow, multi-chain settlement, and automated PR review features.
+2. **Repository Owner / Maintainer Direct Engagement**: Craft tailored proposals highlighting how Ubiquibot reduces maintainer review overhead by up to 80% while securing rewards via multi-sig escrows.
+3. **Showcase Integration**: Offer zero-friction one-click setup (`ubiquibot.config.yml` template) for instant deployment.
+
+---
+
+## 4. Metrics & KPI Tracking
+- **Discovery Rate**: Number of target repositories identified per week (>100).
+- **Engagement Conversion**: Outreach response rate from maintainers (>15%).
+- **Onboarding Rate**: Net new repositories adopting Ubiquibot per month (>10).
+- **Total Value Locked (TVL)**: Total bounty dollars escrowed via Ubiquibot.
+
+---
+
+*Authored by @MochiGem for UbiquityDAO (Business Development)*


### PR DESCRIPTION
## 📝 Summary of Contribution
Resolves #90: Added comprehensive `STRATEGY_GITHUB_MARKETING.md` proposal outlining targeted query discovery, outreach workflows, and KPI tracking for Ubiquibot growth.

Contributed by @MochiGem